### PR TITLE
feat: add support for TYPO3 v14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		}
 	],
 	"require": {
-		"typo3/cms-core": "^12.0 || ^13.0"
+		"typo3/cms-core": "^12.0 || ^13.0 || ^14.0"
 	},
 	"require-dev": {
 		"armin/editorconfig-cli": "^2.0",
@@ -24,9 +24,8 @@
 		"friendsoftypo3/content-blocks": "^0.7.18 || ^1.0.0",
 		"helhum/typo3-console": "^8.0",
 		"helmich/typo3-typoscript-lint": "^3.2",
-		"nikic/php-parser": "4.19.4 as 5.3.1",
-		"saschaegerer/phpstan-typo3": "^1.1",
-		"ssch/typo3-rector": "^2.10",
+		"saschaegerer/phpstan-typo3": "^1.1 || ^2.0",
+		"ssch/typo3-rector": "^2.10 || ^3.0",
 		"symfony/translation": "^7.1"
 	},
 	"autoload": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,7 +11,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '2.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.4.0-13.4.99',
+            'typo3' => '12.4.0-14.3.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/php-cs-fixer.php
+++ b/php-cs-fixer.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the TYPO3 CMS project.
  *

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,13 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method Blueways\\\\BwJsoneditor\\\\Form\\\\Element\\\\JsonEditor\\:\\:render\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Blueways\\BwJsoneditor\\Form\\Element\\JsonEditor\:\:render\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: Classes/Form/Element/JsonEditor.php
 
 		-
-			message: "#^Property Blueways\\\\BwJsoneditor\\\\Form\\\\Element\\\\JsonEditor\\:\\:\\$defaultFieldInformation type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Blueways\\BwJsoneditor\\Form\\Element\\JsonEditor\:\:\$defaultFieldInformation type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: Classes/Form/Element/JsonEditor.php

--- a/rector.php
+++ b/rector.php
@@ -6,7 +6,6 @@ use Rector\Config\RectorConfig;
 use Rector\PostRector\Rector\NameImportingPostRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
 use Rector\ValueObject\PhpVersion;
-use Ssch\TYPO3Rector\CodeQuality\General\ConvertImplicitVariablesToExplicitGlobalsRector;
 use Ssch\TYPO3Rector\CodeQuality\General\ExtEmConfRector;
 use Ssch\TYPO3Rector\Configuration\Typo3Option;
 use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
@@ -16,7 +15,6 @@ return RectorConfig::configure()
     ->withPaths([
         __DIR__ . '/Classes',
         __DIR__ . '/Configuration',
-        __DIR__ . '/config',
         __DIR__ . '/ext_emconf.php',
         __DIR__ . '/ext_localconf.php',
     ])
@@ -26,7 +24,7 @@ return RectorConfig::configure()
     ->withSets([
         Typo3SetList::CODE_QUALITY,
         Typo3SetList::GENERAL,
-        Typo3LevelSetList::UP_TO_TYPO3_13,
+        Typo3LevelSetList::UP_TO_TYPO3_14,
     ])
     // To have a better analysis from PHPStan, we teach it here some more things
     ->withPHPStanConfigs([
@@ -34,11 +32,10 @@ return RectorConfig::configure()
     ])
     ->withRules([
         AddVoidReturnTypeWhereNoReturnRector::class,
-        ConvertImplicitVariablesToExplicitGlobalsRector::class,
     ])
     ->withConfiguredRule(ExtEmConfRector::class, [
-        ExtEmConfRector::PHP_VERSION_CONSTRAINT => '8.1.0-8.2.99',
-        ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '12.4.0-13.4.99',
+        ExtEmConfRector::PHP_VERSION_CONSTRAINT => '8.2.0-8.4.99',
+        ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '12.4.0-14.3.99',
         ExtEmConfRector::ADDITIONAL_VALUES_TO_BE_REMOVED => [],
     ])
     // If you use withImportNames(), you should consider excluding some TYPO3 files.


### PR DESCRIPTION
  - Add TYPO3 v14 support while keeping v12 and v13 compatibility
  - Update dev tooling to support PHPStan v2 and typo3-rector v3 (with v14 rulesets)
  - No PHP or JavaScript code changes required — all used APIs (AbstractFormElement, JavaScriptModuleInstruction, nodeRegistry) remain stable in v14
