### PR TITLE
feat: acceptance tests

### DIFF
--- a/.ddev/addon-metadata/ddev-selenium-standalone-chrome/manifest.yaml
+++ b/.ddev/addon-metadata/ddev-selenium-standalone-chrome/manifest.yaml
@@ -1,0 +1,9 @@
+name: ddev-selenium-standalone-chrome
+repository: ddev/ddev-selenium-standalone-chrome
+version: 2.1.2
+install_date: "2026-02-28T22:20:20+01:00"
+project_files:
+    - docker-compose.selenium-chrome.yaml
+    - config.selenium-standalone-chrome.yaml
+global_files: []
+removal_actions: []

--- a/.ddev/commands/web/init-typo3
+++ b/.ddev/commands/web/init-typo3
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2086
+set -e
+
+## Description: Initialize TYPO3 installation
+## Usage: init-typo3
+## Example: ddev init-typo3
+
+readonly dbHost="db"
+readonly dbUser="db"
+readonly dbPassword="db"
+readonly dbName="db"
+readonly dbCredentials="-h${dbHost} -u${dbUser} -p${dbPassword}"
+readonly fixturePath="/var/www/html/Tests/Fixtures"
+readonly typo3Binary="/var/www/html/vendor/bin/typo3"
+
+function _progress() {
+    printf "%s... " "$1"
+}
+
+function _done() {
+    printf "\e[32mDone\e[39m\n"
+}
+
+# Create empty database
+_progress "Creating empty database"
+mysql -Nse "SHOW TABLES" $dbCredentials "$dbName" | while read -r table; do
+    mysql -e "DROP TABLE ${table}" $dbCredentials "$dbName"
+done
+_done
+
+# Prepare setup environment
+export TYPO3_DB_DRIVER=mysqli
+export TYPO3_DB_USERNAME="$dbUser"
+export TYPO3_DB_PASSWORD="$dbPassword"
+export TYPO3_DB_PORT=3306
+export TYPO3_DB_HOST="$dbHost"
+export TYPO3_DB_DBNAME="$dbName"
+export TYPO3_SETUP_ADMIN_EMAIL=admin@example.com
+export TYPO3_SETUP_ADMIN_USERNAME=admin
+export TYPO3_SETUP_ADMIN_PASSWORD=Passw0rd!
+export TYPO3_SERVER_TYPE=other
+export TYPO3_PROJECT_NAME="EXT:bw_jsoneditor"
+
+# Set up environment
+_progress "Setting up TYPO3 installation"
+"$typo3Binary" setup --no-interaction --force --quiet
+_done
+
+# Patch entry points to include c3.php for code coverage
+_progress "Patching entry points for code coverage"
+if ! grep -q 'c3.php' /var/www/html/public/index.php; then
+    sed -i '1,/^<?php/s/^<?php/<?php\n\nif (file_exists(dirname(__DIR__) . "\/c3.php")) {\n    include dirname(__DIR__) . "\/c3.php";\n}\n/' /var/www/html/public/index.php
+fi
+if ! grep -q 'c3.php' /var/www/html/public/typo3/index.php; then
+    sed -i '1,/^<?php/s/^<?php/<?php\n\nif (file_exists(dirname(dirname(__DIR__)) . "\/c3.php")) {\n    include dirname(dirname(__DIR__)) . "\/c3.php";\n}\n/' /var/www/html/public/typo3/index.php
+fi
+_done
+
+# Set extension configuration
+_progress "Setting up configuration"
+"$typo3Binary" configuration:set SYS/trustedHostsPattern '.*.*' --no-interaction --quiet
+"$typo3Binary" cache:flush
+_done
+
+# Import DB fixtures
+for file in "$fixturePath"/*.sql; do
+    _progress "Importing DB fixture \"$(basename "$file")\""
+    mysql $dbCredentials "$dbName" < "$file"
+    _done
+done

--- a/.ddev/config.selenium-standalone-chrome.yaml
+++ b/.ddev/config.selenium-standalone-chrome.yaml
@@ -1,0 +1,31 @@
+#ddev-generated
+# Remove the line above if you don't want this file to be overwritten when you run
+# ddev get ddev/ddev-selenium-standalone-chrome
+#
+# This file comes from https://github.com/ddev/ddev-selenium-standalone-chrome
+#
+web_environment:
+  - BROWSERTEST_OUTPUT_DIRECTORY=/tmp
+  - BROWSERTEST_OUTPUT_BASE_URL=${DDEV_PRIMARY_URL}
+  - SIMPLETEST_BASE_URL=http://web
+  - SIMPLETEST_DB=mysql://db:db@db/db
+  # Use disable-dev-shm-usage instead of setting shm_usage
+  # https://developers.google.com/web/tools/puppeteer/troubleshooting#tips
+  # The format of chromeOptions is defined at https://chromedriver.chromium.org/capabilities
+  - MINK_DRIVER_ARGS_WEBDRIVER=[\"chrome\", {\"browserName\":\"chrome\",\"goog:chromeOptions\":{\"w3c\":true,\"args\":[\"--disable-dev-shm-usage\",\"--disable-gpu\",\"--headless\",\"--dns-prefetch-disable\"]}}, \"http://selenium-chrome:4444/wd/hub\"]
+  # Nightwatch
+  - DRUPAL_TEST_BASE_URL=http://web
+  - DRUPAL_TEST_DB_URL=mysql://db:db@db/db
+  - DRUPAL_TEST_WEBDRIVER_HOSTNAME=selenium-chrome
+  - DRUPAL_TEST_WEBDRIVER_PORT=4444
+  - DRUPAL_TEST_WEBDRIVER_PATH_PREFIX=/wd/hub
+  - DRUPAL_TEST_WEBDRIVER_W3C=true
+  # --window-size=1920,1080 is needed to fix random timeouts in tests. See: https://community.latenode.com/t/selenium-webdriver-timeout-issue-when-running-in-headless-mode-with-c/21952/4
+  - DRUPAL_TEST_WEBDRIVER_CHROME_ARGS=--disable-dev-shm-usage --disable-gpu --headless --dns-prefetch-disable --window-size=1920,1080
+  - DRUPAL_TEST_CHROMEDRIVER_AUTOSTART=false
+  - DRUPAL_NIGHTWATCH_SEARCH_DIRECTORY=../
+  - DRUPAL_NIGHTWATCH_IGNORE_DIRECTORIES=node_modules,vendor,.*,sites/*/files,sites/*/private,sites/simpletest
+  - DRUPAL_NIGHTWATCH_OUTPUT=reports/nightwatch
+  # DTT
+  - DTT_BASE_URL=http://web
+  - DTT_MINK_DRIVER_ARGS=[\"chrome\", {\"browserName\":\"chrome\",\"goog:chromeOptions\":{\"w3c\":true,\"args\":[\"--disable-dev-shm-usage\",\"--disable-gpu\",\"--headless\",\"--dns-prefetch-disable\"]}}, \"http://selenium-chrome:4444/wd/hub\"]

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,23 +1,22 @@
 name: bw-jsoneditor
 type: typo3
 docroot: public
-php_version: "8.2"
+php_version: "8.3"
 webserver_type: nginx-fpm
 router_http_port: "80"
 router_https_port: "443"
 xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []
+webimage_extra_packages: [php8.3-pcov, libxml2-utils]
 database:
   type: mariadb
   version: "10.4"
-nfs_mount_enabled: false
-mutagen_enabled: false
+omit_containers: [ddev-ssh-agent]
 use_dns_when_possible: true
 composer_version: "2"
-web_environment: []
 nodejs_version: "16"
-webimage_extra_packages: [libxml2-utils]
+web_environment: []
 
 # Key features of ddev's config.yaml:
 

--- a/.ddev/docker-compose.selenium-chrome.yaml
+++ b/.ddev/docker-compose.selenium-chrome.yaml
@@ -1,0 +1,33 @@
+#ddev-generated
+# Remove the line above if you don't want this file to be overwritten when you run
+# ddev get ddev/ddev-selenium-standalone-chrome
+#
+# This file comes from https://github.com/ddev/ddev-selenium-standalone-chrome
+#
+services:
+  selenium-chrome:
+    image: selenium/standalone-chromium:138.0
+    container_name: ddev-${DDEV_SITENAME}-selenium-chrome
+    expose:
+      #      The internal noVNC port, which operates over HTTP so it can be exposed
+      #      through the router.
+      - 7900
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTPS_EXPOSE=7900:7900
+      - HTTP_EXPOSE=7910:7900
+      - VNC_NO_PASSWORD=1
+        # Enables multiple parallel connections to the Selenium.
+      - SE_NODE_MAX_SESSIONS=12
+      - SE_NODE_OVERRIDE_MAX_SESSIONS=true
+    # To enable VNC access for traditional VNC clients like macOS "Screen Sharing",
+    # uncomment the following two lines.
+    #ports:
+    #  - "5900:5900"
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    volumes:
+      # To enable file uploads in E2E tests.
+      - "../:/var/www/html"
+      - ".:/mnt/ddev_config"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,14 +1,11 @@
 /.ddev export-ignore
 /.github export-ignore
-/node_modules export-ignore
 /Tests export-ignore
-/var export-ignore
-/vendor export-ignore
 /.editorconfig export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /codeception.yml export-ignore
-/composer.lock export-ignore
+/ext_tables.sql export-ignore
 /packaging_exclude.php export-ignore
 /php-cs-fixer.php export-ignore
 /phpstan.neon export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+/.ddev export-ignore
+/.github export-ignore
+/node_modules export-ignore
+/Tests export-ignore
+/var export-ignore
+/vendor export-ignore
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/codeception.yml export-ignore
+/composer.lock export-ignore
+/packaging_exclude.php export-ignore
+/php-cs-fixer.php export-ignore
+/phpstan.neon export-ignore
+/phpstan-baseline.neon export-ignore
+/rector.php export-ignore

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -31,9 +31,6 @@ jobs:
           ddev composer config github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
           ddev composer install
 
-      - name: Composer audit
-        run: ddev composer audit
-
       - name: Run static code analysis
         run: ddev composer ci:sca
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
           new_command_on_retry: ddev composer ci:test:acceptance -- -g failed
 
       # Save acceptance reports
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: acceptance-reports-${{ matrix.php-version }}-${{ matrix.typo3-version }}
           path: Tests/Acceptance/_output

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,67 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+      - 'renovate/**'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tests:
+    name: Tests (PHP ${{ matrix.php-version }}, TYPO3 ${{ matrix.typo3-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        typo3-version: ["12.4", "13.4"]
+        php-version: ["8.3"]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+          extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql
+
+      - name: Setup DDEV
+        uses: ddev/github-action-setup-ddev@v1
+        with:
+          autostart: false
+
+      - name: Configure and start DDEV
+        run: |
+          ddev config --project-type=typo3 --php-version=${{ matrix.php-version }}
+          ddev start
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v2
+        with:
+          composer-options: --with=typo3/cms-core:"^${{ matrix.typo3-version }}"
+
+      - name: Init TYPO3
+        run: ddev init-typo3
+
+      - name: Run acceptance tests
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          retry_on: error
+          timeout_minutes: 10
+          command: ddev composer ci:test:acceptance
+          new_command_on_retry: ddev composer ci:test:acceptance -- -g failed
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: acceptance-reports-${{ matrix.php-version }}-${{ matrix.typo3-version }}
+          path: Tests/Acceptance/_output

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,14 +16,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        typo3-version: ["12.4", "13.4"]
-        php-version: ["8.3"]
+        typo3-version: [ "12.4", "13.4" ]
+        php-version: [ "8.3" ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
+      # Prepare environment
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         env:
@@ -33,24 +34,27 @@ jobs:
           coverage: none
           extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql
 
+      # Setup DDEV
       - name: Setup DDEV
         uses: ddev/github-action-setup-ddev@v1
         with:
           autostart: false
-
       - name: Configure and start DDEV
         run: |
           ddev config --project-type=typo3 --php-version=${{ matrix.php-version }}
           ddev start
 
+      # Install dependencies
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
         with:
           composer-options: --with=typo3/cms-core:"^${{ matrix.typo3-version }}"
 
+      # Init TYPO3
       - name: Init TYPO3
         run: ddev init-typo3
 
+      # Run tests
       - name: Run acceptance tests
         uses: nick-fields/retry@v3
         with:
@@ -60,8 +64,16 @@ jobs:
           command: ddev composer ci:test:acceptance
           new_command_on_retry: ddev composer ci:test:acceptance -- -g failed
 
-      - uses: actions/upload-artifact@v4
-        if: failure()
+      # Save acceptance reports
+      - uses: actions/upload-artifact@v6
         with:
           name: acceptance-reports-${{ matrix.php-version }}-${{ matrix.typo3-version }}
           path: Tests/Acceptance/_output
+        if: failure()
+
+      # Report coverage
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5.5.2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./Tests/Acceptance/_output/coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ package-lock.json
 c3.php
 config/
 ContentBlocks/
+Tests/Acceptance/_output
+Tests/Acceptance/Support/_generated

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ node_modules
 !Resources/Public
 Documentation-*
 package-lock.json
-
+c3.php
 config/
+ContentBlocks/

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,3 @@ Documentation-*
 package-lock.json
 
 config/
-Configuration/TCA/Overrides/tt_content.php
-ContentBlocks/
-ext_tables.sql

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tt_content', [
+    'json' => [
+        'label' => 'Example JSON',
+        'description' => 'This editor has some nice features like syntax highlighting, validation and more.',
+        'config' => [
+            'type' => 'user',
+            'renderType' => 'jsonEditor',
+        ],
+    ],
+]);
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+    'tt_content',
+    'json',
+    'textmedia',
+    'after:bodytext'
+);

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Supported TYPO3 versions](https://typo3-badges.dev/badge/bw_jsoneditor/typo3/shields.svg)](https://extensions.typo3.org/extension/bw_jsoneditor)
 ![Total downloads](https://typo3-badges.dev/badge/bw_jsoneditor/downloads/shields.svg)
 [![Composer](https://typo3-badges.dev/badge/bw_jsoneditor/composer/shields.svg)](https://packagist.org/packages/blueways/bw-jsoneditor)
+[![codecov](https://codecov.io/gh/maikschneider/bw_jsoneditor/graph/badge.svg?token=MW65NLCQY3)](https://codecov.io/gh/maikschneider/bw_jsoneditor)
 
 </div>
 

--- a/Tests/Acceptance/Backend/JsonEditorCest.php
+++ b/Tests/Acceptance/Backend/JsonEditorCest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Blueways\BwJsoneditorTest\Acceptance\Backend;
+
+use Blueways\BwJsoneditorTest\Acceptance\Support\AcceptanceTester;
+
+final class JsonEditorCest
+{
+    private const EDITOR_SELECTOR = '[data-formengine-input-name="data[tt_content][1][json]"]';
+    private const HIDDEN_INPUT_SELECTOR = 'input[type="hidden"][name="data[tt_content][1][json]"]';
+
+    public function _before(AcceptanceTester $I): void
+    {
+        $I->loginAsAdmin();
+    }
+
+    private function openEditorField(AcceptanceTester $I): void
+    {
+        $I->amOnPage('/typo3/record/edit?edit[tt_content][1]=edit');
+        $I->switchToContentFrame();
+        $I->waitForElement(self::EDITOR_SELECTOR, 10);
+        $I->scrollTo(self::EDITOR_SELECTOR);
+        $I->waitForElementVisible(self::EDITOR_SELECTOR, 10);
+    }
+
+    public function canSeeJsonEditorContainer(AcceptanceTester $I): void
+    {
+        $this->openEditorField($I);
+        $I->seeElement(self::EDITOR_SELECTOR);
+    }
+
+    public function canSeeHiddenInputForJsonField(AcceptanceTester $I): void
+    {
+        $this->openEditorField($I);
+        $I->seeElementInDOM(self::HIDDEN_INPUT_SELECTOR);
+    }
+
+    public function canSeeJsonEditorIsInitialized(AcceptanceTester $I): void
+    {
+        $this->openEditorField($I);
+        $I->waitForElementVisible(self::EDITOR_SELECTOR . ' .jse-main', 10);
+    }
+
+    public function canSaveJsonValueAndPersistToDatabase(AcceptanceTester $I): void
+    {
+        $this->openEditorField($I);
+        $I->waitForElementVisible(self::EDITOR_SELECTOR . ' .jse-main', 10);
+
+        $I->executeJS(
+            'const input = document.querySelector(\'input[name="data[tt_content][1][json]"]\');'
+            . 'input.value = \'{"foo":"bar"}\';'
+            . 'input.dispatchEvent(new Event("change", { bubbles: true }));'
+            . 'TYPO3.FormEngine && TYPO3.FormEngine.Validation && TYPO3.FormEngine.Validation.markFieldAsChanged(input);'
+        );
+
+        $I->scrollTo('button[name="_savedok"]');
+        $I->click('button[name="_savedok"]');
+        $I->wait(2);
+        $I->waitForElement(self::EDITOR_SELECTOR, 10);
+
+        $I->canSeeInDatabase('tt_content', ['uid' => 1, 'json' => '{"foo":"bar"}']);
+    }
+
+    public function canSeePrefilledValueFromDatabase(AcceptanceTester $I): void
+    {
+        $I->updateInDatabase('tt_content', ['json' => '{"hello":"world"}'], ['uid' => 1]);
+
+        $this->openEditorField($I);
+
+        $value = $I->grabValueFrom(self::HIDDEN_INPUT_SELECTOR);
+        $I->assertEquals('{"hello":"world"}', $value);
+    }
+}

--- a/Tests/Acceptance/Support/AcceptanceTester.php
+++ b/Tests/Acceptance/Support/AcceptanceTester.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Blueways\BwJsoneditorTest\Acceptance\Support;
+
+use Blueways\BwJsoneditorTest\Acceptance\Support\_generated\AcceptanceTesterActions;
+use Codeception\Actor;
+use TYPO3\TestingFramework\Core\Acceptance\Step\FrameSteps;
+
+/**
+ * Inherited Methods
+ * @method void wantTo($text)
+ * @method void wantToTest($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method void pause($vars = [])
+ * @SuppressWarnings(PHPMD)
+ */
+class AcceptanceTester extends Actor
+{
+    use AcceptanceTesterActions;
+    use FrameSteps;
+
+    public function loginAsAdmin(): void
+    {
+        $I = $this;
+        $I->amOnPage('/typo3');
+        $I->waitForElement('#t3-username', 10);
+        $I->fillField('#t3-username', 'admin');
+        $I->fillField('#t3-password', 'Passw0rd!');
+        $I->wait(1);
+        $I->click('#t3-login-submit-section > button');
+        $I->waitForElement('.scaffold-header', 10);
+    }
+}

--- a/Tests/Acceptance/Support/Extension/EnvironmentExtension.php
+++ b/Tests/Acceptance/Support/Extension/EnvironmentExtension.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Blueways\BwJsoneditorTest\Acceptance\Support\Extension;
+
+use Codeception\Events;
+use Codeception\Extension;
+
+class EnvironmentExtension extends Extension
+{
+    /**
+     * @var array<Events::*, string>
+     */
+    public static array $events = [
+        Events::SUITE_BEFORE => 'beforeSuite',
+    ];
+
+    public function beforeSuite(): void
+    {
+        require_once dirname(__DIR__, 4) . '/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php';
+    }
+}

--- a/Tests/Fixtures/pages.sql
+++ b/Tests/Fixtures/pages.sql
@@ -1,0 +1,3 @@
+INSERT INTO `pages` (`uid`, `pid`, `title`, `slug`, `sys_language_uid`, `l10n_parent`, `l10n_source`,
+                     `doktype`, `is_siteroot`, `TSconfig`)
+VALUES (1, 0, 'Main', '/', 0, 0, 0, 1, 1, '');

--- a/Tests/Fixtures/pages.sql
+++ b/Tests/Fixtures/pages.sql
@@ -1,3 +1,3 @@
 INSERT INTO `pages` (`uid`, `pid`, `title`, `slug`, `sys_language_uid`, `l10n_parent`, `l10n_source`,
-                     `doktype`, `is_siteroot`, `TSconfig`)
+										 `doktype`, `is_siteroot`, `TSconfig`)
 VALUES (1, 0, 'Main', '/', 0, 0, 0, 1, 1, '');

--- a/Tests/Fixtures/tt_content.sql
+++ b/Tests/Fixtures/tt_content.sql
@@ -1,0 +1,2 @@
+INSERT INTO `tt_content` (`uid`, `pid`, `header`, `CType`, `sys_language_uid`, `l18n_parent`)
+VALUES (1, 1, 'Test Content', 'textmedia', 0, 0);

--- a/codeception.yml
+++ b/codeception.yml
@@ -1,0 +1,55 @@
+namespace: Blueways\BwJsoneditorTest\Acceptance\Support
+actor: AcceptanceTester
+paths:
+    tests: Tests
+    output: Tests/Acceptance/_output
+    data: Tests/Acceptance/Fixtures
+    support: Tests/Acceptance/Support
+settings:
+    shuffle: false
+    lint: true
+    colors: true
+    memory_limit: 2048M
+extensions:
+    enabled:
+        - Codeception\Extension\RunFailed
+        - Blueways\BwJsoneditorTest\Acceptance\Support\Extension\EnvironmentExtension
+    config:
+        Codeception\Extension\RunFailed:
+            file: Tests/Acceptance/_output/_failed
+
+suites:
+    Acceptance:
+        actor: AcceptanceTester
+        modules:
+            enabled:
+                - Asserts
+                - Cli
+                - WebDriver
+                - Db
+            config:
+                Asserts: ~
+                WebDriver:
+                    url: 'https://bw-jsoneditor.ddev.site'
+                    browser: chrome
+                    host: selenium-chrome
+                    port: 4444
+                    window_size: 1920x1080
+                    wait: 2
+                    capabilities:
+                        acceptInsecureCerts: true
+                        goog:chromeOptions:
+                            args: ['--disable-dev-shm-usage']
+
+                Db:
+                    dsn: 'mysql:host=db;dbname=db'
+                    user: 'db'
+                    password: 'db'
+                    populate: true
+                    cleanup: false
+                    populator: 'bash .ddev/commands/web/init-typo3'
+
+coverage:
+    enabled: true
+    include:
+        - Classes/*

--- a/composer.json
+++ b/composer.json
@@ -19,23 +19,35 @@
 	},
 	"require-dev": {
 		"armin/editorconfig-cli": "^2.0",
+		"codeception/c3": "^2.9",
+		"codeception/codeception": "^5.1",
+		"codeception/module-asserts": "^3.0",
+		"codeception/module-cli": "^2.0",
+		"codeception/module-db": "^3.2",
+		"codeception/module-webdriver": "^4.0",
 		"ergebnis/composer-normalize": "^2.44",
 		"friendsofphp/php-cs-fixer": "^3.12",
-		"friendsoftypo3/content-blocks": "^0.7.18 || ^1.0.0",
 		"helhum/typo3-console": "^8.0",
 		"helmich/typo3-typoscript-lint": "^3.2",
 		"nikic/php-parser": "4.19.4 as 5.3.1",
 		"saschaegerer/phpstan-typo3": "^1.1",
 		"ssch/typo3-rector": "^2.10",
-		"symfony/translation": "^7.1"
+		"symfony/translation": "^7.1",
+		"typo3/testing-framework": "^8.2 || ^9.0"
 	},
 	"autoload": {
 		"psr-4": {
 			"Blueways\\BwJsoneditor\\": "Classes/"
 		}
 	},
+	"autoload-dev": {
+		"psr-4": {
+			"Blueways\\BwJsoneditorTest\\": "Tests/"
+		}
+	},
 	"config": {
 		"allow-plugins": {
+			"codeception/c3": true,
 			"ergebnis/composer-normalize": true,
 			"helhum/typo3-console-plugin": true,
 			"typo3/class-alias-loader": true,
@@ -53,6 +65,9 @@
 		}
 	},
 	"scripts": {
+		"post-autoload-dump": [
+			"@environment:prepare"
+		],
 		"ci:composer:normalize": "@composer normalize --no-check-lock --dry-run",
 		"ci:editorconfig:lint": "ec --strict --git-only -n",
 		"ci:php:fixer": "php-cs-fixer --config=php-cs-fixer.php fix --dry-run --format=checkstyle > php-cs-fixer.xml || true",
@@ -70,11 +85,15 @@
 			"@ci:xml:lint",
 			"@ci:yaml:lint"
 		],
+		"ci:test:acceptance": "codecept run Acceptance --coverage --coverage-xml",
 		"ci:typoscript:lint": "typoscript-lint --fail-on-warnings",
 		"ci:xml:lint": "find ./ -name '*.xlf' ! -path './vendor/*' ! -path './var/*' | xargs -r xmllint --schema vendor/symfony/translation/Resources/schemas/xliff-core-1.2-transitional.xsd --noout",
 		"ci:yaml:lint": "find ./ ! -path './vendor/*' ! -path '*/node_modules/*' \\( -name '*.yaml' -o -name '*.yml' \\) | xargs -r yaml-lint",
 		"composer:normalize": "@composer normalize --no-check-lock",
 		"editorconfig:lint": "ec --strict --fix --git-only -n",
+		"environment:prepare": [
+			"codecept build"
+		],
 		"php:fixer": "php-cs-fixer --config=php-cs-fixer.php fix",
 		"php:lint": "find *.php . -name '*.php' ! -path './vendor/*'  ! -path './var/*' ! -path '*node_modules/*' -print0 | xargs -0 -n 1 -P 4 php -l",
 		"php:stan": "phpstan --generate-baseline=phpstan-baseline.neon --allow-empty-baseline",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		}
 	],
 	"require": {
-		"typo3/cms-core": "^12.0 || ^13.0"
+		"typo3/cms-core": "^12.4 || ^13.4"
 	},
 	"require-dev": {
 		"armin/editorconfig-cli": "^2.0",
@@ -27,12 +27,21 @@
 		"codeception/module-webdriver": "^4.0",
 		"ergebnis/composer-normalize": "^2.44",
 		"friendsofphp/php-cs-fixer": "^3.12",
-		"helhum/typo3-console": "^8.0",
+		"helhum/typo3-console": "^8.2",
 		"helmich/typo3-typoscript-lint": "^3.2",
-		"nikic/php-parser": "4.19.4 as 5.3.1",
-		"saschaegerer/phpstan-typo3": "^1.1",
-		"ssch/typo3-rector": "^2.10",
+		"saschaegerer/phpstan-typo3": "^1.1 || ^2.1",
+		"ssch/typo3-rector": "^2.10 || ^3.12",
 		"symfony/translation": "^7.1",
+		"typo3/cms-base-distribution": "^12.4 || ^13.4",
+		"typo3/cms-belog": "^12.4 || ^13.4",
+		"typo3/cms-beuser": "^12.4 || ^13.4",
+		"typo3/cms-extensionmanager": "^12.4 || ^13.4",
+		"typo3/cms-filelist": "^12.4 || ^13.4",
+		"typo3/cms-info": "^12.4 || ^13.4",
+		"typo3/cms-install": "^12.4 || ^13.4",
+		"typo3/cms-lowlevel": "^12.4 || ^13.4",
+		"typo3/cms-setup": "^12.4 || ^13.4",
+		"typo3/cms-tstemplate": "^12.4 || ^13.4",
 		"typo3/testing-framework": "^8.2 || ^9.0"
 	},
 	"autoload": {
@@ -49,7 +58,6 @@
 		"allow-plugins": {
 			"codeception/c3": true,
 			"ergebnis/composer-normalize": true,
-			"helhum/typo3-console-plugin": true,
 			"typo3/class-alias-loader": true,
 			"typo3/cms-composer-installers": true
 		},

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,0 +1,3 @@
+create table tt_content (
+    json text
+);

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,3 +1,3 @@
 create table tt_content (
-    json text
+		json text
 );

--- a/php-cs-fixer.php
+++ b/php-cs-fixer.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the TYPO3 CMS project.
  *

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,13 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method Blueways\\\\BwJsoneditor\\\\Form\\\\Element\\\\JsonEditor\\:\\:render\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Blueways\\BwJsoneditor\\Form\\Element\\JsonEditor\:\:render\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: Classes/Form/Element/JsonEditor.php
 
 		-
-			message: "#^Property Blueways\\\\BwJsoneditor\\\\Form\\\\Element\\\\JsonEditor\\:\\:\\$defaultFieldInformation type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Blueways\\BwJsoneditor\\Form\\Element\\JsonEditor\:\:\$defaultFieldInformation type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: Classes/Form/Element/JsonEditor.php


### PR DESCRIPTION
This pull request introduces a setup for acceptance testing using Codeception and Selenium within the DDEV environment, and updates the project to support TYPO3 12.4 and 13.4 with PHP 8.3. The changes include new configuration files, test infrastructure, and dependency updates, as well as the addition of a JSON editor field to the `tt_content` table for testing purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure & Tests**
  * Bumped PHP to 8.3 and targeted TYPO3 12.4 / 13.4.
  * New acceptance test suite and CI workflow to run automated tests and collect coverage.

* **Chores**
  * Project configuration and dependency updates; removed the Composer audit step; updated export and ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->